### PR TITLE
Update Travis CI environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+os:
+  - linux
+  - osx
 language: node_js
 node_js:
-  - "7"
+  - '10'
+  - '8'
   - "6"
   - "4"
+cache: npm


### PR DESCRIPTION
## Update Travis CI environment config to:

*   remove node version 7
*   add node version 8 (currently maintained LTS)
*   add node version 10 (currently maintained and node major LTS)
*   add tests on macOs (Windows builds on Travis CI are **very** unstable as of today)

This PR fixes the first item on #1 issue.