### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/gakimball/prepend-cwd#readme",
   "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.2.0",
-    "xo": "^0.18.1"
+    "chai": "^4.2.0",
+    "mocha": "^5.2.0",
+    "xo": "^0.20.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
- Chai and Mocha updated to latest versions.
- XO updated to latest version supported by Node 4 LTS.

This PR fixes the second item on #1 issue.